### PR TITLE
Add handling for 301 (redirect) HTTP response codes

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -94,7 +94,8 @@ def test_url():
         ret = request_url(requests.head, url)
         print(f"status_code: {ret}")
 
-        if ret.status_code != 200:
+        # Check if the response status code is 200 or 301 (redirect)
+        if ret.status_code not in [200, 301]:
             relative_path = extract_relative_path(url, root_dir)
 
             if relative_path:


### PR DESCRIPTION
This commit enhances the URL testing script to handle HTTP response codes 301 (redirect) in addition to 200 (OK). Previously, the script only considered 200 as a valid response code. With this enhancement, URLs that return a 301 status code will also be treated as valid, ensuring comprehensive testing for URL accessibility.

Changes Made:
- Updated the test_url() function in the test script to include handling for HTTP response code 301.
- Modified the condition within the loop to check for both 200 and 301 response codes as valid.